### PR TITLE
Fix peak usage using wrong value (#4)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,8 @@ unsafe impl GlobalAlloc for PeakAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let ret = System.alloc(layout);
         if !ret.is_null() {
-            let curr = CURRENT.fetch_add(layout.size(), Ordering::AcqRel);
+            CURRENT.fetch_add(layout.size(), Ordering::AcqRel);
+            let curr = CURRENT.load(Ordering::Acquire);
             PEAK.fetch_max(curr, Ordering::AcqRel);
         }
         ret

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 static CURRENT: AtomicUsize = AtomicUsize::new(0);
 /// This atomic counter monitors the maximum amount of memory (in bytes) that
 /// has been allocated for this process over the course of its life.
-static PEAK   : AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
 
 /// This structure implements a dead simple low-overhead wrapper around the
 /// system allocator. It lets a program know its own memory and peak memory
@@ -106,7 +106,7 @@ impl PeakAlloc {
     }
     /// Resets the peak usage to the value currently in memory
     pub fn reset_peak_usage(&self) {
-        PEAK.store(CURRENT.load(Ordering::Acquire), Ordering::Release);
+        PEAK.store(CURRENT.load(Ordering::Relaxed), Ordering::Relaxed);
     }
     /// Performs the bytes to kilobytes conversion
     fn kb(x: usize) -> f32 {
@@ -124,21 +124,20 @@ impl PeakAlloc {
 
 /// PeakAlloc only implements the minimum required set of methods to make it
 /// useable as a global allocator (with `#[global_allocator]` attribute).
-/// 
+///
 /// No funky stuff is done below.
 unsafe impl GlobalAlloc for PeakAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let ret = System.alloc(layout);
         if !ret.is_null() {
-            CURRENT.fetch_add(layout.size(), Ordering::AcqRel);
-            let curr = CURRENT.load(Ordering::Acquire);
-            PEAK.fetch_max(curr, Ordering::AcqRel);
+            let curr = CURRENT.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
+            PEAK.fetch_max(curr, Ordering::Relaxed);
         }
         ret
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         System.dealloc(ptr, layout);
-        CURRENT.fetch_sub(layout.size(), Ordering::AcqRel);
+        CURRENT.fetch_sub(layout.size(), Ordering::Relaxed);
     }
 }


### PR DESCRIPTION
Suggestion for fixing issue #4 . Note I do not currently understand how atomic ordering works and chose `Ordering::Acquire` because copilot suggested it. Checking that would be nice.